### PR TITLE
Add moment and default date config

### DIFF
--- a/addon/components/article-info.js
+++ b/addon/components/article-info.js
@@ -1,0 +1,6 @@
+import Component from 'ember-component';
+import layout from '../templates/components/article-info';
+
+export default Component.extend({
+  layout
+});

--- a/addon/helpers/format-date.js
+++ b/addon/helpers/format-date.js
@@ -1,0 +1,13 @@
+import moment from 'moment';
+import config from 'ember-get-config';
+import { helper } from 'ember-helper';
+
+const { dateFormat } = config.emberWriter;
+
+export function formatDate([date], { format }={}) {
+  format = format || dateFormat;
+
+  return moment(date).format(format);
+}
+
+export default helper(formatDate);

--- a/addon/templates/components/article-info.hbs
+++ b/addon/templates/components/article-info.hbs
@@ -1,0 +1,4 @@
+  <div class="post-info">
+    <span class="author by-line">{{article.attributes.author}}</span>
+    <span class="date">{{format-date article.attributes.date}}</span>
+  </div>

--- a/addon/templates/index.hbs
+++ b/addon/templates/index.hbs
@@ -11,11 +11,7 @@
         {{html-safe post.summary}}
       </div>
 
-      <div class="post-info">
-        <span class="by-line">{{post.attributes.author}}</span>
-        <span class="separator">-</span>
-        <span class="date">{{post.attributes.date}}</span>
-      </div>
+      {{article-info article=post}}
     </article>
   {{/each}}
 </div>

--- a/addon/templates/post.hbs
+++ b/addon/templates/post.hbs
@@ -1,10 +1,6 @@
 <article>
   <h3>{{model.attributes.title}}</h3>
-  <div class="info">
-    <span class="by-line">{{model.attributes.author}}</span>
-    <span class="separator">-</span>
-    <span class="date">{{model.attributes.date}}</span>
-  </div>
+  {{article-info article=model}}
 
   {{article-content content=model.body}}
 </article>

--- a/app/components/article-info.js
+++ b/app/components/article-info.js
@@ -1,0 +1,1 @@
+export { default } from 'ember-writer/components/article-info';

--- a/app/helpers/format-date.js
+++ b/app/helpers/format-date.js
@@ -1,0 +1,1 @@
+export { default, formatDate } from 'ember-writer/helpers/format-date';

--- a/index.js
+++ b/index.js
@@ -18,6 +18,16 @@ module.exports = {
     } else {
       this.blogDirectory = path.join(this.app.project.root, '/blog');
     }
+
+    this.addonConfig = app.project.config(process.env.EMBER_ENV).emberWriter || {};
+  },
+
+  config: function(/*environment, appConfig*/) {
+    return {
+      'emberWriter': {
+        dateFormat: 'MM-DD-YYYY'
+      }
+    };
   },
 
   treeForPublic(tree) {
@@ -31,7 +41,7 @@ module.exports = {
       destDir: 'api/blog'
     });
 
-    this.markdownParser = new BlogMarkdownParser(blogFiles);
+    this.markdownParser = new BlogMarkdownParser(blogFiles, this.addonConfig);
     trees.push(this.markdownParser);
 
     return new MergeTrees(trees);

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "ember-cli-inject-live-reload": "^1.4.0",
     "ember-cli-jshint": "^1.0.0",
     "ember-cli-mocha": "0.10.4",
+    "ember-cli-moment-shim": "2.0.0",
     "ember-cli-release": "^0.2.9",
     "ember-cli-sri": "^2.1.0",
     "ember-cli-template-lint": "0.4.12",
@@ -38,6 +39,7 @@
     "ember-disable-prototype-extensions": "^1.1.0",
     "ember-engines": "0.3.0",
     "ember-export-application-global": "^1.0.5",
+    "ember-get-config": "0.1.7",
     "ember-load-initializers": "^0.5.1",
     "ember-resolver": "^2.0.3",
     "ember-suave": "4.0.0",
@@ -62,7 +64,8 @@
     "front-matter": "^2.1.0",
     "fs-extra": "^0.30.0",
     "path": "^0.12.7",
-    "showdown": "^1.4.3"
+    "showdown": "^1.4.3",
+    "moment": "^2.8.0"
   },
   "ember-addon": {
     "configPath": "tests/dummy/config"

--- a/tests/dummy/app/styles/app.css
+++ b/tests/dummy/app/styles/app.css
@@ -177,6 +177,11 @@ github.com style (c) Vasily Polovnyov <vast@whiteants.net>
   flex: 1;
 }
 
+.author:after {
+  padding: 0 0.5rem 0 0.75rem;
+  content: '-';
+}
+
 /* articles */
 article {
   padding-bottom: 2rem;

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,6 +16,10 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
+    },
+
+    emberWriter: {
+      dateFormat: 'MMMM DD, YYYY'
     }
   };
 

--- a/tests/integration/components/article-info-test.js
+++ b/tests/integration/components/article-info-test.js
@@ -1,0 +1,52 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+  describeComponent,
+  it
+} from 'ember-mocha';
+import {
+  describe,
+  beforeEach
+} from 'mocha';
+import hbs from 'htmlbars-inline-precompile';
+
+describeComponent(
+  'article-info',
+  'Integration: ArticleInfoComponent',
+  {
+    integration: true
+  },
+  function() {
+    describe('article with author and date attributes', function() {
+      beforeEach(function() {
+        this.set('article', {
+          attributes: {
+            author: 'Dave',
+            date: new Date('2015-06-22')
+          }
+        });
+
+        this.render(hbs`{{article-info article=article}}`);
+      });
+
+      it('shows the author', function() {
+        expect(this.$(`.author:contains(Dave)`)).to.have.length(1);
+      });
+
+      it('shows the date', function() {
+        expect(this.$(`.date:contains(June)`)).to.have.length(1);
+      });
+    });
+
+    /*
+      TODO: The below is left in to workaround a but in 2.8-beta.3. It works
+      in canary (fixed in https://github.com/emberjs/ember.js/commit/447df33c4db30c475a08415196dbb7012f08cc07)
+
+      Remove as soon as beta.4 is cut.
+     */
+    it('renders', function() {
+      this.render(hbs`{{article-info}}`);
+      expect(this.$()).to.have.length(1);
+    });
+  }
+);

--- a/tests/unit/helpers/format-date-test.js
+++ b/tests/unit/helpers/format-date-test.js
@@ -1,0 +1,43 @@
+/* jshint expr:true */
+import { expect } from 'chai';
+import {
+  describe,
+  beforeEach,
+  it
+} from 'mocha';
+import {
+  formatDate
+} from 'ember-writer/helpers/format-date';
+import moment from 'moment';
+import config from 'ember-get-config';
+
+describe('FormatDateHelper', function() {
+  describe('with provided format', function() {
+    let result;
+
+    beforeEach(function() {
+      let date = new Date('2016-10-31');
+      let format = { format: 'MMMM' };
+      result = formatDate([date], format);
+    });
+
+    it('formats the date using moment', function() {
+      expect(result).to.equal('October');
+    });
+  });
+
+  describe('with no format', function() {
+    let result;
+    let date;
+
+    beforeEach(function() {
+      date = new Date('2016-10-31');
+      result = formatDate([date]);
+    });
+
+    it('falls back to the format in ENV', function() {
+      let expectedFormat = moment(date).format(config.emberWriter.dateFormat);
+      expect(result).to.equal(expectedFormat);
+    });
+  });
+});


### PR DESCRIPTION
This pulls in moment.js, but not through the normal addon in an attempt to keep filesize down a bit (we dont need all the extra components or the timezone support).

For now this is configured via ENV, but I'd like to do a followup PR to move config into a separate file (see #17).
- adds default dateFormat (defaults to MM-DD-YYYY)
- adds article-info component
- adds format-date helper

Fixes #2.
Merge ~~#1~~ & #4 first.
