### PR TITLE
Allow configuration via `config/ember-writer`

### DIFF
--- a/blueprints/article/index.js
+++ b/blueprints/article/index.js
@@ -7,11 +7,6 @@ const moment = require('moment');
 module.exports = {
   description: 'Generates a new blog article',
 
-  // normalizeEntityName: function(name) {
-  //   return name;
-  //   // return name.dasherize();
-  // },
-
   fileMapTokens: function() {
     return {
       __blogDir__: function(options) {
@@ -38,8 +33,4 @@ module.exports = {
       title: options.entity.name
     };
   }
-
-  // afterInstall: function(options) {
-  //   // Perform extra work here.
-  // }
 };

--- a/blueprints/ember-writer/files/config/ember-writer.js
+++ b/blueprints/ember-writer/files/config/ember-writer.js
@@ -1,0 +1,7 @@
+/*jshint node:true*/
+
+// Use this file to configure Ember Writer. Commented lines are the defaults.
+
+module.exports = {
+  // dateFormat: 'MM-DD-YYYY'
+};

--- a/config/ember-writer.js
+++ b/config/ember-writer.js
@@ -1,0 +1,7 @@
+/*jshint node:true*/
+
+// Use this file to configure Ember Writer. Commented lines are the defaults.
+
+module.exports = {
+  // dateFormat: 'MM-DD-YYYY'
+};

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@
 const Funnel = require('broccoli-funnel');
 const MergeTrees = require('broccoli-merge-trees');
 const BlogMarkdownParser = require('./lib/blog-markdown-parser');
+const itemCounts = require('./lib/utils/item-counts');
 const path = require('path');
 const fs = require('fs-extra');
 const _array = require('lodash/array');
@@ -12,21 +13,30 @@ const _string = require('lodash/string');
 module.exports = {
   name: 'ember-writer',
 
+  /**
+   * Stores the config object.
+   * @type {Object}
+   * @property
+   * @public
+   */
+  addonConfig: null,
+
   included(app) {
     if (app.project.pkg['ember-addon'] && !app.project.pkg['ember-addon'].paths) {
       this.blogDirectory = path.resolve(app.project.root, path.join('tests', 'dummy', 'blog'));
     } else {
-      this.blogDirectory = path.join(this.app.project.root, '/blog');
+      this.blogDirectory = path.join(app.project.root, '/blog');
     }
-
-    this.addonConfig = app.project.config(process.env.EMBER_ENV).emberWriter || {};
   },
 
-  config: function(/*environment, appConfig*/) {
+  config: function() {
+    let appConfig = require('./config/ember-writer');
+    let config = getDefaultConfig();
+
+    this.addonConfig = Object.assign(config, appConfig);
+
     return {
-      'emberWriter': {
-        dateFormat: 'MM-DD-YYYY'
-      }
+      emberWriter: this.addonConfig
     };
   },
 
@@ -98,13 +108,13 @@ module.exports = {
   }
 };
 
-function itemCounts(array) {
-  let counts = {};
-
-  array.forEach((thing) => {
-    let count = counts[thing] || 0;
-    counts[thing] = count += 1;
-  });
-
-  return counts;
+/**
+ * The default config for Ember Writer
+ * @return {Object} The config
+ * @public
+ */
+function getDefaultConfig() {
+  return {
+    dateFormat: 'MM-DD-YYYY'
+  };
 }

--- a/lib/utils/item-counts.js
+++ b/lib/utils/item-counts.js
@@ -1,0 +1,23 @@
+/* jshint node: true */
+'use strict';
+
+/**
+ * Returns an object where array elements are keys, and the number of times
+ * the element appears in the array is the value.
+ *
+ * @param  {Array} array The array to count elements on
+ * @return {[type]} An object with counts
+ * @public
+ */
+function itemCounts(array=[]) {
+  let counts = {};
+
+  array.forEach((thing) => {
+    let count = counts[thing] || 0;
+    counts[thing] = count += 1;
+  });
+
+  return counts;
+}
+
+module.exports = itemCounts;

--- a/node-tests/index-test.js
+++ b/node-tests/index-test.js
@@ -1,0 +1,62 @@
+/* jshint node: true */
+'use strict';
+
+const AddonIndex = require('../index');
+const expect = require('chai').expect;
+
+describe('AddonIndex', function() {
+  describe('included', function() {
+    describe('in addon', function() {
+      beforeEach(function() {
+        let fakeApp = {
+          project: {
+            root: '/',
+            pkg: {
+              'ember-addon': true
+            }
+          }
+        };
+
+        AddonIndex.included(fakeApp);
+      });
+
+      it('sets blogDirectory to the dummy path', function() {
+        let { blogDirectory } = AddonIndex;
+        expect(blogDirectory).to.equal('/tests/dummy/blog');
+      });
+    });
+
+    describe('in normal project', function() {
+      beforeEach(function() {
+        let fakeApp = {
+          project: {
+            root: '/',
+            pkg: {}
+          }
+        };
+
+        AddonIndex.included(fakeApp);
+      });
+
+      it('sets blogDirectory to the root path', function() {
+        let { blogDirectory } = AddonIndex;
+        expect(blogDirectory).to.equal('/blog');
+      });
+    });
+  });
+
+  describe('config', function() {
+    it('sets addonConfig', function() {
+      expect(AddonIndex.addonConfig).to.be.null;
+
+      AddonIndex.config();
+
+      expect(AddonIndex.addonConfig).to.not.be.empty;
+    });
+
+    it('returns the config to be merged into the main config', function() {
+      let result = AddonIndex.config();
+      expect(result.emberWriter).to.not.be.empty;
+    });
+  });
+});

--- a/node-tests/lib/blog-markdown-parser-test.js
+++ b/node-tests/lib/blog-markdown-parser-test.js
@@ -3,8 +3,6 @@
 
 const BlogMarkdownParser = require('../../lib/blog-markdown-parser');
 const expect = require('chai').expect;
-const fs = require('fs-extra');
-const path = require('path');
 
 let parser;
 describe('BlogMarkdownParser', function() {

--- a/node-tests/lib/utils/item-counts-test.js
+++ b/node-tests/lib/utils/item-counts-test.js
@@ -1,0 +1,22 @@
+/* jshint node: true */
+'use strict';
+
+const itemCounts = require('../../../lib/utils/item-counts');
+const expect = require('chai').expect;
+
+describe('itemCounts', function() {
+  describe('with array', function() {
+    let result;
+
+    beforeEach(function() {
+      let array = ['one', 'two', 'three', 'two', 'two', 'one'];
+      result = itemCounts(array);
+    });
+
+    it('returns the counts in the result object', function() {
+      expect(result.one).to.equal(2);
+      expect(result.two).to.equal(3);
+      expect(result.three).to.equal(1);
+    });
+  });
+});

--- a/tests/dummy/config/environment.js
+++ b/tests/dummy/config/environment.js
@@ -16,10 +16,6 @@ module.exports = function(environment) {
     APP: {
       // Here you can pass flags/options to your application instance
       // when it is created
-    },
-
-    emberWriter: {
-      dateFormat: 'MMMM DD, YYYY'
     }
   };
 

--- a/tests/integration/components/article-info-test.js
+++ b/tests/integration/components/article-info-test.js
@@ -9,6 +9,7 @@ import {
   beforeEach
 } from 'mocha';
 import hbs from 'htmlbars-inline-precompile';
+import { formatDate } from 'ember-writer/helpers/format-date';
 
 describeComponent(
   'article-info',
@@ -18,11 +19,13 @@ describeComponent(
   },
   function() {
     describe('article with author and date attributes', function() {
+      let date = new Date('2015-06-22');
+
       beforeEach(function() {
         this.set('article', {
           attributes: {
             author: 'Dave',
-            date: new Date('2015-06-22')
+            date
           }
         });
 
@@ -34,7 +37,8 @@ describeComponent(
       });
 
       it('shows the date', function() {
-        expect(this.$(`.date:contains(June)`)).to.have.length(1);
+        let expectedDateFormat = formatDate([date]);
+        expect(this.$(`.date:contains(${expectedDateFormat})`)).to.have.length(1);
       });
     });
 


### PR DESCRIPTION
- Creates config/ember-writer as part of the addon blueprint
- Moves itemCounts function to a util
- Merges config file and default config into app config via the addon
  `config` hook
- Adds a few tests for `index.js`
- Removes config from the environment file

Fixes #17.
Merge #13 first.
