### PR TITLE
Add draft articles

### DIFF
--- a/node-tests/index-test.js
+++ b/node-tests/index-test.js
@@ -3,6 +3,10 @@
 
 const AddonIndex = require('../index');
 const expect = require('chai').expect;
+const EmberAddon = require('ember-cli/lib/broccoli/ember-addon');
+const fs = require('fs-extra');
+const path = require('path');
+const temp = require('temp');
 
 describe('AddonIndex', function() {
   describe('included', function() {
@@ -57,6 +61,206 @@ describe('AddonIndex', function() {
     it('returns the config to be merged into the main config', function() {
       let result = AddonIndex.config();
       expect(result.emberWriter).to.not.be.empty;
+    });
+  });
+
+  describe('postBuild', function() {
+    let tempDir;
+    let blogPath;
+    this.timeout(1000);
+
+    beforeEach(function() {
+      let tmproot = path.resolve(__dirname, '../tmp');
+      // tempDir = fs.mkdtempSync(`${tmproot}${path.sep}`);
+      tempDir = temp.mkdirSync('post-build');
+      blogPath = path.join(tempDir, 'api', 'blog');
+      fs.mkdirsSync(blogPath);
+      let dataPath = path.join(tempDir, 'data');
+      fs.mkdirsSync(dataPath);
+
+      fs.writeFileSync(path.join(dataPath, 'authors.js'), 'module.exports=[{ name: "Dave" }]');
+    });
+
+    describe('posts.json', function() {
+      describe('in production', function() {
+        beforeEach(function() {
+          let fakeApp = {
+            env: 'production',
+            project: {
+              root: '/',
+              pkg: {}
+            }
+          };
+
+          let fakeMarkdownParser = {
+            parsedPosts: [
+              {
+                attributes: {
+                  author: 'Dave',
+                  title: 'Draft Post',
+                  published: false
+                }
+              },
+              {
+                attributes: {
+                  author: 'Dave',
+                  title: 'Published Post'
+                }
+              }
+            ]
+          };
+
+          AddonIndex.app = fakeApp;
+          AddonIndex.blogDirectory = tempDir;
+          AddonIndex.markdownParser = fakeMarkdownParser;
+          AddonIndex.postBuild({
+            directory: tempDir
+          });
+        });
+
+        it('does not include draft articles', function() {
+          let articles = fs.readJSONSync(`${blogPath}/posts.json`);
+          let draftArticle = articles.find((a) => a.attributes.title === 'Draft Post');
+
+          expect(draftArticle).to.be.undefined;
+        });
+      });
+
+      describe('in development', function() {
+        beforeEach(function() {
+          let fakeApp = {
+            env: 'development',
+            project: {
+              root: '/',
+              pkg: {}
+            }
+          };
+
+          let fakeMarkdownParser = {
+            parsedPosts: [
+              {
+                attributes: {
+                  author: 'Dave',
+                  title: 'Draft Post',
+                  published: false
+                }
+              },
+              {
+                attributes: {
+                  author: 'Dave',
+                  title: 'Published Post'
+                }
+              }
+            ]
+          };
+
+          AddonIndex.app = fakeApp;
+          AddonIndex.blogDirectory = tempDir;
+          AddonIndex.markdownParser = fakeMarkdownParser;
+          AddonIndex.postBuild({
+            directory: tempDir
+          });
+        });
+
+        it('includes draft articles', function() {
+          let articles = fs.readJSONSync(`${blogPath}/posts.json`);
+          let draftArticle = articles.find((a) => a.attributes.title === 'Draft Post');
+
+          expect(draftArticle).to.be.ok;
+        });
+      });
+    });
+
+    describe('tags.json', function() {
+      beforeEach(function() {
+        let fakeApp = {
+          env: 'development',
+          project: {
+            root: '/',
+            pkg: {}
+          }
+        };
+
+        let fakeMarkdownParser = {
+          parsedPosts: [
+            {
+              attributes: {
+                author: 'Dave',
+                tags: 'ember, testing'
+              }
+            },
+            {
+              attributes: {
+                author: 'Dave',
+                tags: 'testing,cycling'
+              }
+            }
+          ]
+        };
+
+        AddonIndex.app = fakeApp;
+        AddonIndex.blogDirectory = tempDir;
+        AddonIndex.markdownParser = fakeMarkdownParser;
+        AddonIndex.postBuild({
+          directory: tempDir
+        });
+      });
+
+      it('creates tags with post counts', function() {
+        let tags = fs.readJSONSync(`${blogPath}/tags.json`);
+        let tagNames = tags.map((t) => t.name);
+        let emberTag = tags.find((t) => t.name === 'ember');
+        let testingTag = tags.find((t) => t.name === 'testing');
+
+        expect(tags).to.have.length(3);
+        expect(tagNames).to.contain('ember', 'testing', 'cycling');
+        expect(emberTag.postCount).to.equal(1);
+        expect(testingTag.postCount).to.equal(2);
+      });
+    });
+
+    describe('authors.json', function() {
+      beforeEach(function() {
+        let fakeApp = {
+          env: 'development',
+          project: {
+            root: '/',
+            pkg: {}
+          }
+        };
+
+        let fakeMarkdownParser = {
+          parsedPosts: [
+            {
+              attributes: {
+                author: 'Dave',
+                tags: 'ember, testing'
+              }
+            },
+            {
+              attributes: {
+                author: 'Dave',
+                tags: 'testing,cycling'
+              }
+            }
+          ]
+        };
+
+        AddonIndex.app = fakeApp;
+        AddonIndex.blogDirectory = tempDir;
+        AddonIndex.markdownParser = fakeMarkdownParser;
+        AddonIndex.postBuild({
+          directory: tempDir
+        });
+      });
+
+      it('creates authors with post counts', function() {
+        let authors = fs.readJSONSync(`${blogPath}/authors.json`);
+        let dave = authors.find((a) => a.name === 'Dave');
+
+        expect(authors).to.have.length(1);
+        expect(dave.postCount).to.equal(2);
+      });
     });
   });
 });

--- a/tests/dummy/blog/2016-08-30-draft-article.md
+++ b/tests/dummy/blog/2016-08-30-draft-article.md
@@ -1,0 +1,15 @@
+---
+title: Draft Article
+date: Tue Aug 30 2016 12:19:38 GMT-0400 (EDT)
+author: Chris Ball
+tags:
+published: false
+---
+
+I'm a **new** article summary! READMORE
+
+This is the main body:
+
+```js
+alert('hi!');
+```


### PR DESCRIPTION
This introduces the concept of draft articles. The presence of `published: false` in the YAML front matter indicates a draft.
- Adds missing node tests for json generated in `postBuild`
- Draft articles are included when in development
- Draft articles are NOT included when outside of development

Fixes #16 
